### PR TITLE
Fix PHPCS violations

### DIFF
--- a/tests/Capability/ResourcesCapabilityTest.php
+++ b/tests/Capability/ResourcesCapabilityTest.php
@@ -16,21 +16,21 @@ use MCP\Server\Tests\Capability\ResourcesCapabilityParameterizedResource;
 
 class ResourcesCapabilityTest extends TestCase
 {
-    private ResourcesCapability $_capability;
+    private ResourcesCapability $capability;
 
     protected function setUp(): void
     {
-        $this->_capability = new ResourcesCapability();
+        $this->capability = new ResourcesCapability();
         $staticAnnotations = new Annotations(audience: ['user'], priority: 0.7);
         // Pass name, mimeType, size, annotations to ResourcesCapabilityMockResource constructor
-        $this->_capability->addResource(
+        $this->capability->addResource(
             new ResourcesCapabilityMockResource('Static Test Resource', 'text/plain', 123, $staticAnnotations)
         );
     }
 
     public function testGetCapabilities(): void
     {
-        $caps = $this->_capability->getCapabilities();
+        $caps = $this->capability->getCapabilities();
         $this->assertArrayHasKey('resources', $caps);
         $this->assertArrayHasKey('subscribe', $caps['resources']);
         $this->assertArrayHasKey('listChanged', $caps['resources']);
@@ -39,7 +39,7 @@ class ResourcesCapabilityTest extends TestCase
     public function testHandleList(): void
     {
         $request = new JsonRpcMessage('resources/list', [], '1');
-        $response = $this->_capability->handleMessage($request);
+        $response = $this->capability->handleMessage($request);
 
         $this->assertNotNull($response);
         $this->assertNull($response->error);
@@ -64,7 +64,7 @@ class ResourcesCapabilityTest extends TestCase
             ['uri' => 'test://static'],
             '1'
         );
-        $response = $this->_capability->handleMessage($request);
+        $response = $this->capability->handleMessage($request);
 
         $this->assertNotNull($response);
         $this->assertNull($response->error);
@@ -80,7 +80,7 @@ class ResourcesCapabilityTest extends TestCase
 
     public function testHandleReadWithParameters(): void
     {
-        $this->_capability->addResource(
+        $this->capability->addResource(
             new ResourcesCapabilityParameterizedResource("User Data", "application/json")
         );
         $request = new JsonRpcMessage(
@@ -88,7 +88,7 @@ class ResourcesCapabilityTest extends TestCase
             ['uri' => 'test://users/123'],
             '1'
         );
-        $response = $this->_capability->handleMessage($request);
+        $response = $this->capability->handleMessage($request);
 
         $this->assertNotNull($response);
         $this->assertNull($response->error);
@@ -115,7 +115,7 @@ class ResourcesCapabilityTest extends TestCase
             ['uri' => 'test://unknown'],
             '1'
         );
-        $response = $this->_capability->handleMessage($request);
+        $response = $this->capability->handleMessage($request);
 
         $this->assertNotNull($response);
         $this->assertNotNull($response->error, "Response should be an error object.");
@@ -126,7 +126,7 @@ class ResourcesCapabilityTest extends TestCase
     public function testHandleMissingUri(): void
     {
         $request = new JsonRpcMessage('resources/read', [], '1');
-        $response = $this->_capability->handleMessage($request);
+        $response = $this->capability->handleMessage($request);
 
         $this->assertNotNull($response);
         $this->assertNotNull($response->error, "Response should be an error object.");

--- a/tests/ServerErrorHandlingTest.php
+++ b/tests/ServerErrorHandlingTest.php
@@ -10,15 +10,15 @@ use MCP\Server\Tests\Util\MockTransport;
 
 class ServerErrorHandlingTest extends TestCase
 {
-    private Server $_server;
-    private MockTransport $_transport;
+    private Server $server;
+    private MockTransport $transport;
 
     protected function setUp(): void
     {
-        $this->_server = new Server('test-server', '1.0.0');
-        $this->_transport = new MockTransport();
-        $this->_server->connect($this->_transport);
-        $this->_transport->reset(); // Ensure clean transport for each test
+        $this->server = new Server('test-server', '1.0.0');
+        $this->transport = new MockTransport();
+        $this->server->connect($this->transport);
+        $this->transport->reset(); // Ensure clean transport for each test
     }
 
     public function testHandlesCapabilityInitializationFailure(): void
@@ -44,17 +44,17 @@ class ServerErrorHandlingTest extends TestCase
             {
             }
         };
-        $this->_server->addCapability($failingCap);
+        $this->server->addCapability($failingCap);
 
         $initMessage = new JsonRpcMessage(
             'initialize',
             ['protocolVersion' => '2025-03-26', 'clientInfo' => ['name' => 'c', 'version' => '1']],
             'init_fail_1'
         );
-        $this->_transport->queueIncomingMessages([$initMessage]);
-        $this->_server->run();
+        $this->transport->queueIncomingMessages([$initMessage]);
+        $this->server->run();
 
-        $sentMessages = $this->_transport->getAllSentMessages();
+        $sentMessages = $this->transport->getAllSentMessages();
         $this->assertCount(1, $sentMessages);
         $response = $sentMessages[0];
         $this->assertNotNull($response);
@@ -88,7 +88,7 @@ class ServerErrorHandlingTest extends TestCase
                 throw new \RuntimeException('Shutdown failed');
             }
         };
-        $this->_server->addCapability($failingCap);
+        $this->server->addCapability($failingCap);
 
         $initMessage = new JsonRpcMessage(
             'initialize',
@@ -97,11 +97,11 @@ class ServerErrorHandlingTest extends TestCase
         );
         $shutdownMessage = new JsonRpcMessage('shutdown', [], 'shutdown_fail_1');
 
-        $this->_transport->queueIncomingMessages([$initMessage]);
-        $this->_transport->queueIncomingMessages([$shutdownMessage]);
-        $this->_server->run();
+        $this->transport->queueIncomingMessages([$initMessage]);
+        $this->transport->queueIncomingMessages([$shutdownMessage]);
+        $this->server->run();
 
-        $sentMessages = $this->_transport->getAllSentMessages();
+        $sentMessages = $this->transport->getAllSentMessages();
         // Expect 2 responses: successful init, then error for shutdown
         $this->assertCount(2, $sentMessages);
 
@@ -180,8 +180,8 @@ class ServerErrorHandlingTest extends TestCase
             }
         };
 
-        $this->_server->addCapability($cap1);
-        $this->_server->addCapability($cap2);
+        $this->server->addCapability($cap1);
+        $this->server->addCapability($cap2);
 
         $initMessage = new JsonRpcMessage(
             'initialize',
@@ -190,11 +190,11 @@ class ServerErrorHandlingTest extends TestCase
         );
         $shutdownMessage = new JsonRpcMessage('shutdown', [], 'shutdown_order_1');
 
-        $this->_transport->queueIncomingMessages([$initMessage]);
-        $this->_transport->queueIncomingMessages([$shutdownMessage]);
-        $this->_server->run();
+        $this->transport->queueIncomingMessages([$initMessage]);
+        $this->transport->queueIncomingMessages([$shutdownMessage]);
+        $this->server->run();
 
-        $sentMessages = $this->_transport->getAllSentMessages();
+        $sentMessages = $this->transport->getAllSentMessages();
         $this->assertCount(2, $sentMessages); // Init response, Shutdown response
 
         // Check shutdown order matches registration order

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2,8 +2,6 @@
 
 namespace MCP\Server\Tests;
 
-require_once __DIR__ . '/Transport/StdioTransportTest.php';
-
 use PHPUnit\Framework\TestCase;
 use MCP\Server\Server;
 use MCP\Server\Capability\CapabilityInterface;


### PR DESCRIPTION
This commit addresses PHPCS warnings identified in the codebase.

The following changes were made:

- `tests/ServerTest.php`: I removed an unnecessary `require_once` statement that caused a `PSR1.Files.SideEffects.FoundWithSymbols` warning. Autoloading handles the class dependency.
- `tests/ServerErrorHandlingTest.php`: I renamed properties `$_server` to `$server` and `$_transport` to `$transport` to comply with `PSR2.Classes.PropertyDeclaration.Underscore`.
- `tests/Capability/ResourcesCapabilityTest.php`: I renamed property `$_capability` to `$capability` to comply with `PSR2.Classes.PropertyDeclaration.Underscore`.

I ran all tests before and after these changes to ensure no regressions were introduced. PHPUnit tests continue to pass, and PHPStan errors remain unchanged (to be addressed separately).