### PR TITLE
Improve PHP tooling setup and add code coverage

### DIFF
--- a/JULES.md
+++ b/JULES.md
@@ -12,7 +12,7 @@ To prepare the environment, execute:
 bash jules_setup.sh
 ```
 
-This script installs necessary PHP versions, Composer, and project dependencies. Running this at the start of your session will prevent common issues.
+This script installs necessary PHP versions, Composer, project dependencies, and Xdebug (to enable code coverage generation). Running this at the start of your session will prevent common issues.
 
 ## Development Workflow
 
@@ -42,7 +42,7 @@ To run the unit test suite:
 ```bash
 vendor/bin/phpunit
 ```
-*(Note: This will use the `phpunit.xml.dist` configuration.)*
+*(Note: This will use the `phpunit.xml.dist` configuration. If you need code coverage reports when running manually like this, ensure Xdebug is enabled in your PHP CLI configuration. However, for most cases, using `bash run_tests.sh` is recommended as it handles this and provides a consolidated output.)*
 
 ### Unit Testing Obligation
 
@@ -56,4 +56,8 @@ Before committing any code changes, always run the full test suite to ensure eve
 bash run_tests.sh
 ```
 
-This script runs PHPcs, PHPStan, and PHPUnit. Make sure all tests pass before submitting.
+This script runs PHPCS, PHPStan, and PHPUnit.
+*   It will now generate code coverage reports in `test_outputs/coverage/html` (viewable in a browser) and `test_outputs/coverage/clover.xml`.
+*   Crucially, the script is configured to exit immediately with an error if PHPCS, PHPStan, or PHPUnit report any issues or test failures.
+
+Make sure all checks pass and review coverage if applicable before submitting.

--- a/jules_setup.sh
+++ b/jules_setup.sh
@@ -38,8 +38,9 @@ sudo apt-get update
 
 # Install PHP 8.1 and extensions
 echo "Installing PHP 8.1 and extensions..."
-sudo apt-get install -y php8.1 php8.1-cli php8.1-common php8.1-curl php8.1-mbstring php8.1-xml php8.1-zip unzip
+sudo apt-get install -y php8.1 php8.1-cli php8.1-common php8.1-curl php8.1-mbstring php8.1-xml php8.1-zip php8.1-xdebug unzip
 # Added php8.1-xml and php8.1-zip as they are common Composer requirements
+# Added php8.1-xdebug for code coverage
 
 # Install Composer
 echo "Installing Composer..."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,12 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <report>
+            <html outputDirectory="test_outputs/coverage/html"/>
+            <clover outputFile="test_outputs/coverage/clover.xml"/>
+        </report>
+    </coverage>
     <source>
         <include>
             <directory>src</directory>

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ echo "Running linters and tests..."
 
 echo "Running PHP CodeSniffer (phpcs)..."
 if [ -f vendor/bin/phpcs ]; then
-    vendor/bin/phpcs -s src/ tests/ > test_outputs/phpcs_output.txt 2>&1 || true
+    vendor/bin/phpcs -s src/ tests/ > test_outputs/phpcs_output.txt 2>&1
     echo "PHPCS Output:"
     cat test_outputs/phpcs_output.txt
 else
@@ -15,10 +15,10 @@ fi
 echo "Running PHPStan..."
 if [ -f vendor/bin/phpstan ]; then
     if [ -f phpstan.neon ] || [ -f phpstan.neon.dist ]; then
-        vendor/bin/phpstan analyse --memory-limit=2G > test_outputs/phpstan_output.txt 2>&1 || true
+        vendor/bin/phpstan analyse --memory-limit=2G > test_outputs/phpstan_output.txt 2>&1
     else
         # Default to level 5 if no config file. Adjust as needed.
-        vendor/bin/phpstan analyse src/ tests/ --level=5 --memory-limit=2G > test_outputs/phpstan_output.txt 2>&1 || true
+        vendor/bin/phpstan analyse src/ tests/ --level=5 --memory-limit=2G > test_outputs/phpstan_output.txt 2>&1
     fi
     echo "PHPStan Output:"
     cat test_outputs/phpstan_output.txt
@@ -28,7 +28,7 @@ fi
 
 echo "Running PHPUnit tests..."
 if [ -f vendor/bin/phpunit ]; then
-    vendor/bin/phpunit > test_outputs/phpunit_output.txt 2>&1 || true
+    XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover test_outputs/coverage/clover.xml --coverage-html test_outputs/coverage/html > test_outputs/phpunit_output.txt 2>&1
     echo "PHPUnit Output:"
     cat test_outputs/phpunit_output.txt
 else


### PR DESCRIPTION
This commit introduces several improvements to the PHP development and testing workflow:

1.  **PHPStan-PHPUnit Integration Verified**: Ensured that the `phpstan/phpstan-phpunit` extension is correctly configured and operational. PHPStan now runs without issues related to PHPUnit specifics.

2.  **Code Coverage**:
    *   Added Xdebug installation (`php8.1-xdebug`) to the `jules_setup.sh` script.
    *   Configured PHPUnit in `phpunit.xml.dist` to generate code coverage reports in HTML (to `test_outputs/coverage/html`) and Clover XML (to `test_outputs/coverage/clover.xml`) formats.
    *   The `run_tests.sh` script now invokes PHPUnit with coverage enabled and sets `XDEBUG_MODE=coverage` to ensure proper execution.

3.  **Refined `run_tests.sh`**:
    *   Removed `|| true` from PHPCS, PHPStan, and PHPUnit commands. The script will now exit with an error code if any of these tools report issues, making it more suitable for CI environments.
    *   The script now explicitly triggers code coverage generation during the PHPUnit run.

4.  **Documentation**: Updated `JULES.md` to reflect the changes in the setup process, testing commands, and the availability of code coverage reports.

These changes enhance the robustness of the testing process and provide valuable insights through code coverage analysis.