### PR TITLE
Fix PHPStan and PHPcs issues

### DIFF
--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -10,7 +10,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Laminas\Diactoros\ResponseFactory;      // For default factory
 use Laminas\Diactoros\StreamFactory;       // For default factory
-use Laminas\Diactoros\ServerRequestFactory; // For default request
+use Laminas\Diactoros\ServerRequestFactory;
+
+// For default request
 
 class HttpTransport extends AbstractTransport
 {
@@ -19,7 +21,7 @@ class HttpTransport extends AbstractTransport
     private ?ResponseInterface $response = null;
     private bool $responsePrepared = false; // To track if send() has been called
 
-    private ServerRequestInterface $request;
+    protected ServerRequestInterface $request;
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -417,11 +417,11 @@ class ServerTest extends TestCase
         ];
         $mockRequest = $this->createMockRequest($initRequestPayload);
         $httpTransport->setMockRequest($mockRequest);
-        
+
         // No actual output is emitted in tests, SapiEmitter is bypassed by not being in SAPI env
         // or by headers_sent being true (which we can't easily mock here without PECL functions)
         // The key is that $httpTransport->getResponse() will contain what *would* be emitted.
-        
+
         // Suppress output from SapiEmitter if it tries to run
         // One way is to ensure headers are "sent"
         // @runInSeparateProcess might be needed if SapiEmitter is hard to control
@@ -479,7 +479,7 @@ class ServerTest extends TestCase
         $capturedMalformedResponse = $httpTransport->getCapturedResponse();
         $this->assertNotNull($capturedMalformedResponse);
         // HttpTransport now sends JSON-RPC errors with HTTP 200
-        $this->assertEquals(200, $capturedMalformedResponse->getStatusCode()); 
+        $this->assertEquals(200, $capturedMalformedResponse->getStatusCode());
         $malformedBody = json_decode((string) $capturedMalformedResponse->getBody(), true);
         $this->assertEquals(JsonRpcMessage::PARSE_ERROR, $malformedBody['error']['code']);
         $this->assertNull($malformedBody['id']);
@@ -498,7 +498,7 @@ class ServerTest extends TestCase
         $capturedUnknownResponse = $httpTransport->getCapturedResponse();
         $this->assertNotNull($capturedUnknownResponse);
         // HttpTransport now sends JSON-RPC errors with HTTP 200
-        $this->assertEquals(200, $capturedUnknownResponse->getStatusCode()); 
+        $this->assertEquals(200, $capturedUnknownResponse->getStatusCode());
         $unknownBody = json_decode((string) $capturedUnknownResponse->getBody(), true);
         $this->assertEquals($unknownMethodId, $unknownBody['id']);
         $this->assertEquals(JsonRpcMessage::METHOD_NOT_FOUND, $unknownBody['error']['code']);


### PR DESCRIPTION
This commit addresses various PHPStan and PHPcs issues identified in your codebase.

PHPcs issues, primarily related to PSR-12 formatting (header spacing and trailing whitespace), were automatically corrected.

PHPStan issues were manually addressed as follows:
- In `src/Transport/HttpTransport.php`:
    - Changed visibility of the `$request` property from `private` to `protected` to allow access from the child class `tests/Transport/TestableHttpTransport.php`.
- In `tests/Transport/TestableHttpTransport.php`:
    - Replaced an undefined constant `TransportException::CODE_EMPTY_REQUEST_BODY` with the existing constant `MCP\Server\Message\JsonRpcMessage::INVALID_REQUEST`.
    - Removed a redundant `if ($response === null)` check, as the relevant method `HttpTransport::getResponse()` is type-hinted to always return a `Psr\Http\Message\ResponseInterface` and never null.

All linters now pass without any reported errors.