### PR TITLE
Fix: Improve test coverage for StdioTransport::receive()

### DIFF
--- a/src/Transport/StdioTransport.php
+++ b/src/Transport/StdioTransport.php
@@ -55,15 +55,6 @@ class StdioTransport extends AbstractTransport
             // Attempt to decode as JSON. We need to inspect its structure.
             $decodedInput = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
 
-            if ($decodedInput === null && json_last_error() !== JSON_ERROR_NONE) {
-                // This case should ideally be caught by JSON_THROW_ON_ERROR,
-                // but as a safeguard or for older PHP versions.
-                throw new \RuntimeException(
-                    'JSON Parse Error: ' . json_last_error_msg(),
-                    JsonRpcMessage::PARSE_ERROR
-                );
-            }
-
             // Check for batch request: a non-empty numerically indexed array
             if (
                 is_array($decodedInput)


### PR DESCRIPTION
Removes an unreachable `if` condition in `StdioTransport::receive()` that was made redundant by the use of `JSON_THROW_ON_ERROR`.

Adds new unit tests to `StdioTransportTest.php` to cover specific exception scenarios in `StdioTransport::receive()`:

1.  `testReceiveInvalidJsonStructureThrowsException`: Ensures that when the input is valid JSON but not a valid JSON-RPC message structure (e.g., a JSON scalar like a string or number), a RuntimeException with the message 'Invalid JSON-RPC message structure.' (wrapped as 'Error parsing JSON-RPC message: ...') is thrown and caught by the generic exception handler.

2.  `testReceiveCatchesExceptionFromJsonRpcMessage`: Ensures that if `JsonRpcMessage::fromJson()` throws an exception (e.g., due to a missing 'method' field in a request), this exception is caught by the generic `catch (\Exception $e)` block in `StdioTransport::receive()` and re-thrown as a RuntimeException.

These changes increase the test coverage for `StdioTransport::receive()` and ensure its error handling paths are behaving as expected.