### PR TITLE
Fix: Modify `run_tests.sh` to run all tests and exit non-zero if any …

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-set -e # Exit immediately if a command exits with a non-zero status.
+final_exit_code=0
 
 echo "Running linters and tests..."
 
 echo "Running PHP CodeSniffer (phpcs)..."
 if [ -f vendor/bin/phpcs ]; then
     vendor/bin/phpcs -s src/ tests/ > test_outputs/phpcs_output.txt 2>&1
+    phpcs_exit_code=$?
+    if [ $phpcs_exit_code -ne 0 ]; then
+        final_exit_code=1
+    fi
     echo "PHPCS Output:"
     cat test_outputs/phpcs_output.txt
 else
@@ -20,6 +24,10 @@ if [ -f vendor/bin/phpstan ]; then
         # Default to level 5 if no config file. Adjust as needed.
         vendor/bin/phpstan analyse src/ tests/ --level=5 --memory-limit=2G > test_outputs/phpstan_output.txt 2>&1
     fi
+    phpstan_exit_code=$?
+    if [ $phpstan_exit_code -ne 0 ]; then
+        final_exit_code=1
+    fi
     echo "PHPStan Output:"
     cat test_outputs/phpstan_output.txt
 else
@@ -29,6 +37,10 @@ fi
 echo "Running PHPUnit tests..."
 if [ -f vendor/bin/phpunit ]; then
     XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover test_outputs/coverage/clover.xml --coverage-html test_outputs/coverage/html > test_outputs/phpunit_output.txt 2>&1
+    phpunit_exit_code=$?
+    if [ $phpunit_exit_code -ne 0 ]; then
+        final_exit_code=1
+    fi
     echo "PHPUnit Output:"
     cat test_outputs/phpunit_output.txt
 else
@@ -36,3 +48,4 @@ else
 fi
 
 echo "Linters and tests completed."
+exit $final_exit_code


### PR DESCRIPTION
…fail

The `run_tests.sh` script has been updated to ensure all defined test suites (PHPCS, PHPStan, PHPUnit) are executed, regardless of individual test failures.

Previously, the script used `set -e`, which caused it to terminate immediately upon the first test failure. This change removes `set -e` and introduces a mechanism to track the exit status of each testing stage. The script will now exit with a status of 0 if all tests pass, or 1 if any test stage reports an error.

This ensures a more comprehensive test run by default, providing you with a full overview of test statuses across the board.