### PR TITLE
I refactored content classes to use a base class for annotations.

### DIFF
--- a/src/Tool/Content/AbstractContent.php
+++ b/src/Tool/Content/AbstractContent.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tool\Content;
+
+/**
+ * Abstract base class for content items.
+ * Manages common annotation functionality.
+ */
+abstract class AbstractContent implements ContentItemInterface
+{
+    protected ?Annotations $annotations;
+
+    /**
+     * Constructs a new AbstractContent instance.
+     *
+     * @param Annotations|null $annotations Optional annotations.
+     */
+    public function __construct(?Annotations $annotations = null)
+    {
+        $this->annotations = $annotations;
+    }
+
+    /**
+     * Prepares the annotations part of the array representation.
+     * This method is intended to be used by subclasses in their toArray() implementations.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getAnnotationsArray(): array
+    {
+        if ($this->annotations !== null) {
+            $annotationsArray = $this->annotations->toArray();
+            if (!empty($annotationsArray)) {
+                return ['annotations' => $annotationsArray];
+            }
+        }
+        return [];
+    }
+
+    /**
+     * Converts the common content item properties (i.e., annotations) to an array.
+     * Subclasses should merge this with their specific data.
+     *
+     * @return array<string, mixed> The array representation of the common parts.
+     */
+    public function toArray(): array
+    {
+        return $this->getAnnotationsArray();
+    }
+}

--- a/src/Tool/Content/AbstractMediaContent.php
+++ b/src/Tool/Content/AbstractMediaContent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tool\Content;
+
+/**
+ * Abstract base class for media content items like audio and images.
+ * Manages common properties like base64 data and MIME type.
+ */
+abstract class AbstractMediaContent extends AbstractContent
+{
+    protected string $data;
+    protected string $mimeType;
+
+    /**
+     * Constructs a new AbstractMediaContent instance.
+     *
+     * @param string $base64Data The base64 encoded media data.
+     * @param string $mimeType The MIME type of the media.
+     * @param Annotations|null $annotations Optional annotations.
+     */
+    public function __construct(
+        string $base64Data,
+        string $mimeType,
+        ?Annotations $annotations = null
+    ) {
+        parent::__construct($annotations);
+        $this->data = $base64Data;
+        $this->mimeType = $mimeType;
+    }
+
+    /**
+     * Returns the specific media type string (e.g., "audio", "image").
+     *
+     * @return string
+     */
+    abstract protected function getMediaType(): string;
+
+    /**
+     * Converts the media content item to an array.
+     *
+     * @return array<string, mixed> The array representation of the media content.
+     */
+    public function toArray(): array
+    {
+        $mediaData = [
+            'type' => $this->getMediaType(),
+            'data' => $this->data,
+            'mimeType' => $this->mimeType,
+        ];
+
+        // Merge with annotations from AbstractContent's toArray method
+        return array_merge($mediaData, parent::toArray());
+    }
+}

--- a/src/Tool/Content/AudioContent.php
+++ b/src/Tool/Content/AudioContent.php
@@ -7,14 +7,13 @@ namespace MCP\Server\Tool\Content;
 /**
  * Represents an audio content item, typically containing base64 encoded audio data and its MIME type.
  */
-final class AudioContent implements ContentItemInterface
+final class AudioContent extends AbstractContent // Extend AbstractContent
 {
     /** @var string Base64 encoded audio data. */
     private string $data;
     /** @var string The MIME type of the audio data (e.g., "audio/mpeg"). */
     private string $mimeType;
-    /** @var Annotations|null Optional annotations for the audio content. */
-    private ?Annotations $annotations;
+    // Remove private ?Annotations $annotations;
 
     /**
      * Constructs a new AudioContent instance.
@@ -28,9 +27,9 @@ final class AudioContent implements ContentItemInterface
         string $mimeType,
         ?Annotations $annotations = null
     ) {
+        parent::__construct($annotations); // Call parent constructor
         $this->data = $base64Data;
         $this->mimeType = $mimeType;
-        $this->annotations = $annotations;
     }
 
     /**
@@ -40,18 +39,12 @@ final class AudioContent implements ContentItemInterface
      */
     public function toArray(): array
     {
-        $data = [
+        $contentData = [
             'type' => 'audio',
             'data' => $this->data,
             'mimeType' => $this->mimeType,
         ];
 
-        if ($this->annotations !== null) {
-            $annotationsArray = $this->annotations->toArray();
-            if (!empty($annotationsArray)) {
-                $data['annotations'] = $annotationsArray;
-            }
-        }
-        return $data;
+        return array_merge($contentData, parent::toArray()); // Merge with parent::toArray()
     }
 }

--- a/src/Tool/Content/AudioContent.php
+++ b/src/Tool/Content/AudioContent.php
@@ -7,13 +7,10 @@ namespace MCP\Server\Tool\Content;
 /**
  * Represents an audio content item, typically containing base64 encoded audio data and its MIME type.
  */
-final class AudioContent extends AbstractContent // Extend AbstractContent
+final class AudioContent extends AbstractMediaContent // Extend AbstractMediaContent
 {
-    /** @var string Base64 encoded audio data. */
-    private string $data;
-    /** @var string The MIME type of the audio data (e.g., "audio/mpeg"). */
-    private string $mimeType;
-    // Remove private ?Annotations $annotations;
+    // Properties $data and $mimeType are inherited from AbstractMediaContent
+    // Property $annotations is inherited from AbstractContent (via AbstractMediaContent)
 
     /**
      * Constructs a new AudioContent instance.
@@ -27,24 +24,27 @@ final class AudioContent extends AbstractContent // Extend AbstractContent
         string $mimeType,
         ?Annotations $annotations = null
     ) {
-        parent::__construct($annotations); // Call parent constructor
-        $this->data = $base64Data;
-        $this->mimeType = $mimeType;
+        parent::__construct($base64Data, $mimeType, $annotations); // Call AbstractMediaContent constructor
+    }
+
+    /**
+     * Returns the specific media type string.
+     *
+     * @return string
+     */
+    protected function getMediaType(): string
+    {
+        return 'audio';
     }
 
     /**
      * Converts the audio content to an array.
+     * Delegates to AbstractMediaContent's toArray method.
      *
      * @return array<string, mixed> The array representation of the audio content.
      */
     public function toArray(): array
     {
-        $contentData = [
-            'type' => 'audio',
-            'data' => $this->data,
-            'mimeType' => $this->mimeType,
-        ];
-
-        return array_merge($contentData, parent::toArray()); // Merge with parent::toArray()
+        return parent::toArray(); // All logic is now in AbstractMediaContent
     }
 }

--- a/src/Tool/Content/EmbeddedResource.php
+++ b/src/Tool/Content/EmbeddedResource.php
@@ -8,40 +8,26 @@ use InvalidArgumentException;
 
 /**
  * Represents an embedded resource as a content item.
- * This is used when a tool's output includes the content of a resource directly,
- * rather than just a URI pointing to it. The embedded resource itself
- * should conform to the structure of a TextResourceContents or BlobResourceContents array.
  */
-final class EmbeddedResource implements ContentItemInterface
+final class EmbeddedResource extends AbstractContent // Extend AbstractContent
 {
-    /** @var array{uri: string, text?: string, blob?: string, mimeType?: string} The actual resource data,
-     * typically matching the structure of TextResourceContents or BlobResourceContents.
-     */
+    /** @var array{uri: string, text?: string, blob?: string, mimeType?: string} The actual resource data. */
     private array $resource;
-    /** @var Annotations|null Optional annotations for the embedded resource. */
-    private ?Annotations $annotations;
+    // Remove private ?Annotations $annotations;
 
     /**
      * Constructs a new EmbeddedResource instance.
      *
-     * @param array{uri: string, text?: string, blob?: string, mimeType?: string} $resourceData The resource data, expected to have a 'uri' key,
-     *                            and either a 'text' or a 'blob' key.
-     *                            Optionally, a 'mimeType' key can be included.
-     *                            Example: `['uri' => '/my/data', 'text' => 'hello', 'mimeType' => 'text/plain']`
-     *                            Example: `['uri' => '/my/image', 'blob' => 'base64data', 'mimeType' => 'image/png']`
+     * @param array{uri: string, text?: string, blob?: string, mimeType?: string} $resourceData
      * @param Annotations|null $annotations Optional annotations.
-     * @throws InvalidArgumentException If resource data is invalid (missing keys or incorrect types).
+     * @throws InvalidArgumentException If resource data is invalid.
      */
     public function __construct(
         array $resourceData,
         ?Annotations $annotations = null
     ) {
-        // The 'uri' key and the string types for 'text' (if set) and 'blob' (if set)
-        // are expected to be guaranteed by the caller, aligning with the PHPDoc type:
-        // array{uri: string, text?: string, blob?: string, mimeType?: string}.
-        // Static analysis tools can enforce this at the call site.
+        parent::__construct($annotations); // Call parent constructor
 
-        // This runtime check ensures that at least one of 'text' or 'blob' is provided.
         if (!isset($resourceData['text']) && !isset($resourceData['blob'])) {
             throw new InvalidArgumentException(
                 "EmbeddedResource data must contain either a 'text' or a 'blob' key."
@@ -49,7 +35,6 @@ final class EmbeddedResource implements ContentItemInterface
         }
 
         $this->resource = $resourceData;
-        $this->annotations = $annotations;
     }
 
     /**
@@ -59,17 +44,11 @@ final class EmbeddedResource implements ContentItemInterface
      */
     public function toArray(): array
     {
-        $data = [
+        $contentData = [
             'type' => 'resource',
             'resource' => $this->resource,
         ];
 
-        if ($this->annotations !== null) {
-            $annotationsArray = $this->annotations->toArray();
-            if (!empty($annotationsArray)) {
-                $data['annotations'] = $annotationsArray;
-            }
-        }
-        return $data;
+        return array_merge($contentData, parent::toArray()); // Merge with parent::toArray()
     }
 }

--- a/src/Tool/Content/ImageContent.php
+++ b/src/Tool/Content/ImageContent.php
@@ -7,13 +7,10 @@ namespace MCP\Server\Tool\Content;
 /**
  * Represents an image content item, typically containing base64 encoded image data and its MIME type.
  */
-final class ImageContent extends AbstractContent // Extend AbstractContent
+final class ImageContent extends AbstractMediaContent // Extend AbstractMediaContent
 {
-    /** @var string Base64 encoded image data. */
-    private string $data;
-    /** @var string The MIME type of the image data (e.g., "image/png", "image/jpeg"). */
-    private string $mimeType;
-    // Remove private ?Annotations $annotations;
+    // Properties $data and $mimeType are inherited from AbstractMediaContent
+    // Property $annotations is inherited from AbstractContent (via AbstractMediaContent)
 
     /**
      * Constructs a new ImageContent instance.
@@ -27,24 +24,27 @@ final class ImageContent extends AbstractContent // Extend AbstractContent
         string $mimeType,
         ?Annotations $annotations = null
     ) {
-        parent::__construct($annotations); // Call parent constructor
-        $this->data = $base64Data;
-        $this->mimeType = $mimeType;
+        parent::__construct($base64Data, $mimeType, $annotations); // Call AbstractMediaContent constructor
+    }
+
+    /**
+     * Returns the specific media type string.
+     *
+     * @return string
+     */
+    protected function getMediaType(): string
+    {
+        return 'image';
     }
 
     /**
      * Converts the image content to an array.
+     * Delegates to AbstractMediaContent's toArray method.
      *
      * @return array<string, mixed> The array representation of the image content.
      */
     public function toArray(): array
     {
-        $contentData = [
-            'type' => 'image',
-            'data' => $this->data,
-            'mimeType' => $this->mimeType,
-        ];
-
-        return array_merge($contentData, parent::toArray()); // Merge with parent::toArray()
+        return parent::toArray(); // All logic is now in AbstractMediaContent
     }
 }

--- a/src/Tool/Content/ImageContent.php
+++ b/src/Tool/Content/ImageContent.php
@@ -7,14 +7,13 @@ namespace MCP\Server\Tool\Content;
 /**
  * Represents an image content item, typically containing base64 encoded image data and its MIME type.
  */
-final class ImageContent implements ContentItemInterface
+final class ImageContent extends AbstractContent // Extend AbstractContent
 {
     /** @var string Base64 encoded image data. */
     private string $data;
     /** @var string The MIME type of the image data (e.g., "image/png", "image/jpeg"). */
     private string $mimeType;
-    /** @var Annotations|null Optional annotations for the image content. */
-    private ?Annotations $annotations;
+    // Remove private ?Annotations $annotations;
 
     /**
      * Constructs a new ImageContent instance.
@@ -28,9 +27,9 @@ final class ImageContent implements ContentItemInterface
         string $mimeType,
         ?Annotations $annotations = null
     ) {
+        parent::__construct($annotations); // Call parent constructor
         $this->data = $base64Data;
         $this->mimeType = $mimeType;
-        $this->annotations = $annotations;
     }
 
     /**
@@ -40,18 +39,12 @@ final class ImageContent implements ContentItemInterface
      */
     public function toArray(): array
     {
-        $data = [
+        $contentData = [
             'type' => 'image',
             'data' => $this->data,
             'mimeType' => $this->mimeType,
         ];
 
-        if ($this->annotations !== null) {
-            $annotationsArray = $this->annotations->toArray();
-            if (!empty($annotationsArray)) {
-                $data['annotations'] = $annotationsArray;
-            }
-        }
-        return $data;
+        return array_merge($contentData, parent::toArray()); // Merge with parent::toArray()
     }
 }

--- a/src/Tool/Content/TextContent.php
+++ b/src/Tool/Content/TextContent.php
@@ -7,12 +7,11 @@ namespace MCP\Server\Tool\Content;
 /**
  * Represents a plain text content item.
  */
-final class TextContent implements ContentItemInterface
+final class TextContent extends AbstractContent // Extend AbstractContent
 {
     /** @var string The plain text content. */
     private string $text;
-    /** @var Annotations|null Optional annotations for the text content. */
-    private ?Annotations $annotations;
+    // Remove private ?Annotations $annotations;
 
     /**
      * Constructs a new TextContent instance.
@@ -22,8 +21,8 @@ final class TextContent implements ContentItemInterface
      */
     public function __construct(string $text, ?Annotations $annotations = null)
     {
+        parent::__construct($annotations); // Call parent constructor
         $this->text = $text;
-        $this->annotations = $annotations;
     }
 
     /**
@@ -33,17 +32,11 @@ final class TextContent implements ContentItemInterface
      */
     public function toArray(): array
     {
-        $data = [
+        $contentData = [
             'type' => 'text',
             'text' => $this->text,
         ];
 
-        if ($this->annotations !== null) {
-            $annotationsArray = $this->annotations->toArray();
-            if (!empty($annotationsArray)) {
-                $data['annotations'] = $annotationsArray;
-            }
-        }
-        return $data;
+        return array_merge($contentData, parent::toArray()); // Merge with parent::toArray()
     }
 }

--- a/tests/Tool/Content/AbstractContentTest.php
+++ b/tests/Tool/Content/AbstractContentTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\AbstractContent;
+use MCP\Server\Tool\Content\Annotations;
+use PHPUnit\Framework\TestCase;
+
+class AbstractContentTest extends TestCase
+{
+    public function testToArrayWithAnnotations(): void
+    {
+        $annotations = new Annotations(['user'], 0.8);
+        $content = new ConcreteContent('test_type', 'test_value', $annotations);
+
+        $expectedArray = [
+            'type' => 'test_type',
+            'value' => 'test_value',
+            'annotations' => [
+                'audience' => ['user'],
+                'priority' => 0.8,
+            ],
+        ];
+        $this->assertEquals($expectedArray, $content->toArray());
+    }
+
+    public function testToArrayWithoutAnnotations(): void
+    {
+        $content = new ConcreteContent('test_type', 'test_value', null);
+
+        $expectedArray = [
+            'type' => 'test_type',
+            'value' => 'test_value',
+            // No 'annotations' key
+        ];
+        $this->assertEquals($expectedArray, $content->toArray());
+    }
+
+    public function testToArrayWithEmptyAnnotationsObject(): void
+    {
+        // An Annotations object can be empty if constructed with nulls
+        $annotations = new Annotations(null, null);
+        $content = new ConcreteContent('test_type', 'test_value', $annotations);
+
+        $expectedArray = [
+            'type' => 'test_type',
+            'value' => 'test_value',
+            // No 'annotations' key because the annotations object itself results in an empty array
+        ];
+        $this->assertEquals($expectedArray, $content->toArray());
+    }
+}

--- a/tests/Tool/Content/AbstractMediaContentTest.php
+++ b/tests/Tool/Content/AbstractMediaContentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\Annotations;
+use PHPUnit\Framework\TestCase;
+
+// MockMediaContent is in its own file: MockMediaContent.php
+
+class AbstractMediaContentTest extends TestCase
+{
+    public function testToArrayWithSpecificMediaTypeAndAnnotations(): void
+    {
+        $annotations = new Annotations(['user'], 0.8);
+        $mediaContent = new MockMediaContent('video', 'videodata', 'video/mp4', $annotations);
+
+        $expectedArray = [
+            'type' => 'video', // From MockMediaContent's getMediaType()
+            'data' => 'videodata',
+            'mimeType' => 'video/mp4',
+            'annotations' => [
+                'audience' => ['user'],
+                'priority' => 0.8,
+            ],
+        ];
+        $this->assertEquals($expectedArray, $mediaContent->toArray());
+    }
+
+    public function testToArrayWithoutAnnotations(): void
+    {
+        $mediaContent = new MockMediaContent('audio_test', 'audiodata', 'audio/mpeg', null);
+
+        $expectedArray = [
+            'type' => 'audio_test',
+            'data' => 'audiodata',
+            'mimeType' => 'audio/mpeg',
+            // No 'annotations' key
+        ];
+        $this->assertEquals($expectedArray, $mediaContent->toArray());
+    }
+
+    public function testToArrayWithEmptyAnnotationsObject(): void
+    {
+        $annotations = new Annotations(null, null);
+        $mediaContent = new MockMediaContent('image_test', 'imagedata', 'image/jpeg', $annotations);
+
+        $expectedArray = [
+            'type' => 'image_test',
+            'data' => 'imagedata',
+            'mimeType' => 'image/jpeg',
+            // No 'annotations' key because the annotations object itself results in an empty array
+        ];
+        $this->assertEquals($expectedArray, $mediaContent->toArray());
+    }
+}

--- a/tests/Tool/Content/AnnotationsTest.php
+++ b/tests/Tool/Content/AnnotationsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\Annotations;
+use PHPUnit\Framework\TestCase;
+use InvalidArgumentException;
+
+class AnnotationsTest extends TestCase
+{
+    public function testConstructorValidAudienceAndPriority(): void
+    {
+        $annotations = new Annotations(['user', 'assistant'], 0.5);
+        $this->assertEquals(['user', 'assistant'], $annotations->audience);
+        $this->assertEquals(0.5, $annotations->priority);
+    }
+
+    public function testConstructorInvalidAudienceRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid audience role: admin. Must be 'user' or 'assistant'.");
+        new Annotations(['admin']);
+    }
+
+    public function testConstructorInvalidAudienceRoleType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        // The message will depend on how PHP handles array to string conversion for the message.
+        // We are primarily testing that the type check catches non-string roles.
+        $this->expectExceptionMessageMatches("/Invalid audience role: .*. Must be 'user' or 'assistant'/");
+        new Annotations(['123']); // Pass a string that's not 'user' or 'assistant'
+    }
+
+    public function testConstructorPriorityTooLow(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Priority must be between 0.0 and 1.0.");
+        new Annotations(null, -0.1);
+    }
+
+    public function testConstructorPriorityTooHigh(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Priority must be between 0.0 and 1.0.");
+        new Annotations(null, 1.1);
+    }
+
+    public function testConstructorAllowsNullAudience(): void
+    {
+        $annotations = new Annotations(null, 0.5);
+        $this->assertNull($annotations->audience);
+        $this->assertEquals(0.5, $annotations->priority);
+    }
+
+    public function testConstructorAllowsNullPriority(): void
+    {
+        $annotations = new Annotations(['user'], null);
+        $this->assertEquals(['user'], $annotations->audience);
+        $this->assertNull($annotations->priority);
+    }
+
+    public function testConstructorAllowsNullAudienceAndPriority(): void
+    {
+        $annotations = new Annotations(null, null);
+        $this->assertNull($annotations->audience);
+        $this->assertNull($annotations->priority);
+        // Also test toArray with nulls
+        $this->assertEquals([], $annotations->toArray());
+    }
+
+    public function testToArrayOnlyIncludesSetValues(): void
+    {
+        $annotations1 = new Annotations(['user'], 0.7);
+        $this->assertEquals(['audience' => ['user'], 'priority' => 0.7], $annotations1->toArray());
+
+        $annotations2 = new Annotations(['assistant'], null);
+        $this->assertEquals(['audience' => ['assistant']], $annotations2->toArray());
+
+        $annotations3 = new Annotations(null, 0.3);
+        $this->assertEquals(['priority' => 0.3], $annotations3->toArray());
+
+        $annotations4 = new Annotations(null, null);
+        $this->assertEquals([], $annotations4->toArray());
+    }
+
+    public function testToArrayWithEmptyAudience(): void
+    {
+        // Technically the constructor doesn't allow creating an empty audience array directly if it's invalid,
+        // but if $audience was set to [] post-construction (which it can't be due to type hints/validation),
+        // or if validation changed.
+        // Let's test the valid case of a non-empty audience.
+        $annotations = new Annotations(['user']);
+        $this->assertEquals(['audience' => ['user']], $annotations->toArray());
+    }
+}

--- a/tests/Tool/Content/AudioContentTest.php
+++ b/tests/Tool/Content/AudioContentTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\Annotations;
+use MCP\Server\Tool\Content\AudioContent;
+use PHPUnit\Framework\TestCase;
+
+class AudioContentTest extends TestCase
+{
+    public function testToArrayBasic(): void
+    {
+        $audioContent = new AudioContent('base64data', 'audio/mp3');
+        $expected = [
+            'type' => 'audio',
+            'data' => 'base64data',
+            'mimeType' => 'audio/mp3',
+        ];
+        $this->assertEquals($expected, $audioContent->toArray());
+    }
+
+    public function testToArrayWithAnnotations(): void
+    {
+        $annotations = new Annotations(['user'], 0.9);
+        $audioContent = new AudioContent('base64data2', 'audio/wav', $annotations);
+        $expected = [
+            'type' => 'audio',
+            'data' => 'base64data2',
+            'mimeType' => 'audio/wav',
+            'annotations' => [
+                'audience' => ['user'],
+                'priority' => 0.9,
+            ],
+        ];
+        $this->assertEquals($expected, $audioContent->toArray());
+    }
+
+    public function testToArrayWithEmptyAnnotationsObject(): void
+    {
+        $annotations = new Annotations(null, null); // Creates an "empty" annotations object
+        $audioContent = new AudioContent('base64data3', 'audio/ogg', $annotations);
+        $expected = [
+            'type' => 'audio',
+            'data' => 'base64data3',
+            'mimeType' => 'audio/ogg',
+            // No 'annotations' key because the Annotations object's toArray() is empty
+        ];
+        $this->assertEquals($expected, $audioContent->toArray());
+    }
+}

--- a/tests/Tool/Content/ConcreteContent.php
+++ b/tests/Tool/Content/ConcreteContent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\AbstractContent;
+use MCP\Server\Tool\Content\Annotations;
+
+// Concrete implementation for testing AbstractContent
+class ConcreteContent extends AbstractContent
+{
+    private string $type;
+    private string $value;
+
+    public function __construct(string $type, string $value, ?Annotations $annotations = null)
+    {
+        parent::__construct($annotations);
+        $this->type = $type;
+        $this->value = $value;
+    }
+
+    public function toArray(): array // Ensure this matches the interface if ContentItemInterface is implemented by AbstractContent
+    {
+        $data = [
+            'type' => $this->type,
+            'value' => $this->value,
+        ];
+        return array_merge($data, parent::toArray());
+    }
+}

--- a/tests/Tool/Content/EmbeddedResourceTest.php
+++ b/tests/Tool/Content/EmbeddedResourceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\Annotations;
+use MCP\Server\Tool\Content\EmbeddedResource;
+use PHPUnit\Framework\TestCase;
+use InvalidArgumentException;
+
+class EmbeddedResourceTest extends TestCase
+{
+    public function testToArrayWithTextResource(): void
+    {
+        $resourceData = ['uri' => '/my/data', 'text' => 'hello', 'mimeType' => 'text/plain'];
+        $embeddedResource = new EmbeddedResource($resourceData);
+        $expected = [
+            'type' => 'resource',
+            'resource' => $resourceData,
+        ];
+        $this->assertEquals($expected, $embeddedResource->toArray());
+    }
+
+    public function testToArrayWithBlobResource(): void
+    {
+        $resourceData = ['uri' => '/my/image', 'blob' => 'base64data', 'mimeType' => 'image/png'];
+        $embeddedResource = new EmbeddedResource($resourceData);
+        $expected = [
+            'type' => 'resource',
+            'resource' => $resourceData,
+        ];
+        $this->assertEquals($expected, $embeddedResource->toArray());
+    }
+
+    public function testToArrayWithAnnotations(): void
+    {
+        $resourceData = ['uri' => '/my/doc', 'text' => 'documentation'];
+        $annotations = new Annotations(['assistant'], 0.7);
+        $embeddedResource = new EmbeddedResource($resourceData, $annotations);
+        $expected = [
+            'type' => 'resource',
+            'resource' => $resourceData,
+            'annotations' => [
+                'audience' => ['assistant'],
+                'priority' => 0.7,
+            ],
+        ];
+        $this->assertEquals($expected, $embeddedResource->toArray());
+    }
+
+    public function testConstructorThrowsErrorIfNoTextAndNoBlob(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("EmbeddedResource data must contain either a 'text' or a 'blob' key.");
+        new EmbeddedResource(['uri' => '/my/invalid']);
+    }
+
+    public function testConstructorAllowsTextOnly(): void
+    {
+        $resourceData = ['uri' => '/my/textonly', 'text' => 'some text'];
+        $embeddedResource = new EmbeddedResource($resourceData); // Should not throw
+        $this->assertInstanceOf(EmbeddedResource::class, $embeddedResource);
+        $expected = [
+            'type' => 'resource',
+            'resource' => $resourceData,
+        ];
+        $this->assertEquals($expected, $embeddedResource->toArray());
+    }
+
+    public function testConstructorAllowsBlobOnly(): void
+    {
+        $resourceData = ['uri' => '/my/blobonly', 'blob' => 'some blob data'];
+        $embeddedResource = new EmbeddedResource($resourceData); // Should not throw
+        $this->assertInstanceOf(EmbeddedResource::class, $embeddedResource);
+        $expected = [
+            'type' => 'resource',
+            'resource' => $resourceData,
+        ];
+        $this->assertEquals($expected, $embeddedResource->toArray());
+    }
+
+    public function testToArrayWithEmptyAnnotationsObject(): void
+    {
+        $resourceData = ['uri' => '/my/data', 'text' => 'hello'];
+        $annotations = new Annotations(null, null);
+        $embeddedResource = new EmbeddedResource($resourceData, $annotations);
+        $expected = [
+            'type' => 'resource',
+            'resource' => $resourceData,
+            // No 'annotations' key
+        ];
+        $this->assertEquals($expected, $embeddedResource->toArray());
+    }
+}

--- a/tests/Tool/Content/ImageContentTest.php
+++ b/tests/Tool/Content/ImageContentTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\Annotations;
+use MCP\Server\Tool\Content\ImageContent;
+use PHPUnit\Framework\TestCase;
+
+class ImageContentTest extends TestCase
+{
+    public function testToArrayBasic(): void
+    {
+        $imageContent = new ImageContent('base64imgdata', 'image/png');
+        $expected = [
+            'type' => 'image',
+            'data' => 'base64imgdata',
+            'mimeType' => 'image/png',
+        ];
+        $this->assertEquals($expected, $imageContent->toArray());
+    }
+
+    public function testToArrayWithAnnotations(): void
+    {
+        $annotations = new Annotations(['user', 'assistant'], 1.0);
+        $imageContent = new ImageContent('base64jpegdata', 'image/jpeg', $annotations);
+        $expected = [
+            'type' => 'image',
+            'data' => 'base64jpegdata',
+            'mimeType' => 'image/jpeg',
+            'annotations' => [
+                'audience' => ['user', 'assistant'],
+                'priority' => 1.0,
+            ],
+        ];
+        $this->assertEquals($expected, $imageContent->toArray());
+    }
+
+    public function testToArrayWithEmptyAnnotationsObject(): void
+    {
+        $annotations = new Annotations(null, null);
+        $imageContent = new ImageContent('base64gifdata', 'image/gif', $annotations);
+        $expected = [
+            'type' => 'image',
+            'data' => 'base64gifdata',
+            'mimeType' => 'image/gif',
+            // No 'annotations' key
+        ];
+        $this->assertEquals($expected, $imageContent->toArray());
+    }
+}

--- a/tests/Tool/Content/MockMediaContent.php
+++ b/tests/Tool/Content/MockMediaContent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\AbstractMediaContent;
+use MCP\Server\Tool\Content\Annotations;
+
+/**
+ * Concrete implementation for testing AbstractMediaContent.
+ */
+class MockMediaContent extends AbstractMediaContent
+{
+    private string $mediaType;
+
+    public function __construct(
+        string $mediaType, // To control the output of getMediaType for testing
+        string $base64Data,
+        string $mimeType,
+        ?Annotations $annotations = null
+    ) {
+        parent::__construct($base64Data, $mimeType, $annotations);
+        $this->mediaType = $mediaType;
+    }
+
+    protected function getMediaType(): string
+    {
+        return $this->mediaType;
+    }
+
+    // toArray is inherited and tested via this mock
+}

--- a/tests/Tool/Content/TextContentTest.php
+++ b/tests/Tool/Content/TextContentTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MCP\Server\Tests\Tool\Content;
+
+use MCP\Server\Tool\Content\Annotations;
+use MCP\Server\Tool\Content\TextContent;
+use PHPUnit\Framework\TestCase;
+
+class TextContentTest extends TestCase
+{
+    public function testToArrayBasic(): void
+    {
+        $textContent = new TextContent('Hello, world!');
+        $expected = [
+            'type' => 'text',
+            'text' => 'Hello, world!',
+        ];
+        $this->assertEquals($expected, $textContent->toArray());
+    }
+
+    public function testToArrayWithAnnotations(): void
+    {
+        $annotations = new Annotations(['user'], 0.5);
+        $textContent = new TextContent('Important message', $annotations);
+        $expected = [
+            'type' => 'text',
+            'text' => 'Important message',
+            'annotations' => [
+                'audience' => ['user'],
+                'priority' => 0.5,
+            ],
+        ];
+        $this->assertEquals($expected, $textContent->toArray());
+    }
+
+    public function testToArrayWithEmptyAnnotationsObject(): void
+    {
+        $annotations = new Annotations(null, null);
+        $textContent = new TextContent('Just some text', $annotations);
+        $expected = [
+            'type' => 'text',
+            'text' => 'Just some text',
+            // No 'annotations' key
+        ];
+        $this->assertEquals($expected, $textContent->toArray());
+    }
+}


### PR DESCRIPTION
I introduced an `AbstractContent` base class to handle common annotations logic for Tool Content classes (AudioContent, ImageContent, TextContent, EmbeddedResource).

- I created `AbstractContent` to manage the 'annotations' property and its serialization in `toArray()`.
- I modified AudioContent, ImageContent, TextContent, and EmbeddedResource to extend `AbstractContent` and delegate annotation handling to it.
- I added comprehensive unit tests for Annotations, `AbstractContent`, and all refactored content classes.
- I ensured full code coverage for the changed and new classes.
- All existing and new tests pass, and the codebase meets linting and static analysis standards.

This refactoring reduces code duplication and improves maintainability.