### PR TITLE
I've refactored the Tool class for improved ergonomics and consistency.

### DIFF
--- a/examples/http_server.php
+++ b/examples/http_server.php
@@ -19,12 +19,15 @@ use MCP\Server\Resource\ResourceContents;
 #[ToolAttribute(name: "echo", description: "Echoes back the provided message.")]
 class EchoTool extends BaseTool
 {
+    /**
+     * @return \MCP\Server\Tool\Content\ContentItemInterface
+     */
     protected function doExecute(
         #[Parameter(name: 'message', type: 'string', description: 'The message to echo.')]
         array $arguments
-    ): array {
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
         $message = $arguments['message'] ?? 'Default message if not provided';
-        return [$this->createTextContent("Echo: " . $message)];
+        return $this->text("Echo: " . $message);
     }
 }
 

--- a/examples/stdio_server.php
+++ b/examples/stdio_server.php
@@ -16,12 +16,15 @@ use MCP\Server\Tool\Attribute\Parameter;
 #[ToolAttribute(name: "echo", description: "Echoes back the provided message.")]
 class EchoTool extends BaseTool
 {
+    /**
+     * @return \MCP\Server\Tool\Content\ContentItemInterface
+     */
     protected function doExecute(
         #[Parameter(name: 'message', type: 'string', description: 'The message to echo.')]
         array $arguments
-    ): array {
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
         $message = $arguments['message'] ?? 'Default message if not provided';
-        return [$this->createTextContent("Echo: " . $message)];
+        return $this->text("Echo: " . $message);
     }
 }
 

--- a/src/Tool/Tool.php
+++ b/src/Tool/Tool.php
@@ -203,23 +203,9 @@ abstract class Tool
     {
         $this->validateArguments($arguments);
         $returnedContent = $this->doExecute($arguments); // Can be single item or array
-
-        $contentItems = [];
-        if ($returnedContent instanceof Content\ContentItemInterface) {
-            // If doExecute returns a single item, wrap it in an array
-            $contentItems[] = $returnedContent;
-        } elseif (is_array($returnedContent)) {
-            // If it's already an array, use it directly
-            $contentItems = $returnedContent;
-        } else {
-            // If $returnedContent is not an array and not a ContentItemInterface,
-            // it's an invalid return type from doExecute.
-            throw new \LogicException(
-                'doExecute must return an array of ContentItemInterface objects or a single ContentItemInterface object.'
-            );
-        }
-
+        $contentItems = is_array($returnedContent) ? $returnedContent : [$returnedContent];
         $resultArray = [];
+
         foreach ($contentItems as $item) {
             if (!$item instanceof Content\ContentItemInterface) {
                 // Throw an exception for stricter validation, ensuring all items are correct

--- a/tests/Capability/FailingMockTool.php
+++ b/tests/Capability/FailingMockTool.php
@@ -4,10 +4,15 @@ namespace MCP\Server\Tests\Capability;
 
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('failing', 'Failing Tool')]
 class FailingMockTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     * @throws \RuntimeException Always throws.
+     */
     protected function doExecute(array $arguments): array
     {
         throw new \RuntimeException('Tool execution failed');

--- a/tests/Capability/InvalidSuggestionsTool.php
+++ b/tests/Capability/InvalidSuggestionsTool.php
@@ -4,6 +4,7 @@ namespace MCP\Server\Tests\Capability;
 
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Tool;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('invalidSuggestionsTool', 'Tool that returns invalid suggestions')]
 class InvalidSuggestionsTool extends Tool
@@ -18,6 +19,9 @@ class InvalidSuggestionsTool extends Tool
         $this->suggestionsToReturn = $suggestionsToReturn;
     }
 
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(array $arguments): array
     {
         // Not used for completion tests

--- a/tests/Capability/MockTool.php
+++ b/tests/Capability/MockTool.php
@@ -13,13 +13,13 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class MockTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
     protected function doExecute(
         #[ParameterAttribute('data', type: 'string', description: 'Input data')]
         array $arguments
-    ): array {
-        return [$this->text('Result: ' . $arguments['data'])];
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
+        return $this->text('Result: ' . $arguments['data']);
     }
 
     /**

--- a/tests/Capability/MockTool.php
+++ b/tests/Capability/MockTool.php
@@ -6,16 +6,20 @@ use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
 use MCP\Server\Tool\Attribute\ToolAnnotations;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAnnotations(title: 'Mock Test Tool', readOnlyHint: true)]
 #[ToolAttribute('test', 'Test Tool')]
 class MockTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(
         #[ParameterAttribute('data', type: 'string', description: 'Input data')]
         array $arguments
     ): array {
-        return [$this->createTextContent('Result: ' . $arguments['data'])];
+        return [$this->text('Result: ' . $arguments['data'])];
     }
 
     /**

--- a/tests/Capability/ToolsCapabilityTest.php
+++ b/tests/Capability/ToolsCapabilityTest.php
@@ -253,9 +253,12 @@ class ToolsCapabilityTest extends TestCase
             {
                 $this->shutdownCountRef++;
             }
+            /**
+             * @return array<Content\ContentItemInterface>
+             */
             protected function doExecute(array $arguments): array
             {
-                return [$this->createTextContent('done')];
+                return [$this->text('done')];
             }
         };
 
@@ -312,9 +315,12 @@ class ToolsCapabilityTest extends TestCase
     public function testHandleCompleteDefaultSuggestions(): void
     {
         $basicTool = new #[ToolAttribute('basic', 'Basic Tool')] class extends Tool {
+            /**
+             * @return array<Content\ContentItemInterface>
+             */
             protected function doExecute(array $arguments): array
             {
-                return [$this->createTextContent('done')];
+                return [$this->text('done')];
             }
         };
         $this->capability->addTool($basicTool); // Add to the existing capability instance
@@ -447,6 +453,9 @@ class ToolsCapabilityTest extends TestCase
         // if constructor validation is robust.
         $customBadTool = new #[ToolAttribute('customBadValuesTool', 'Tool with bad values type')] class extends Tool
         {
+            /**
+             * @return array<Content\ContentItemInterface>
+             */
             protected function doExecute(array $arguments): array
             {
                 return [];
@@ -481,6 +490,9 @@ class ToolsCapabilityTest extends TestCase
     public function testHandleCompleteWithToolReturningNonArraySuggestions(): void
     {
         $nonArraySuggestionsTool = new #[ToolAttribute('nonArraySuggestionsTool', 'Tool returning non-array suggestions')] class extends Tool {
+            /**
+             * @return array<Content\ContentItemInterface>
+             */
             protected function doExecute(array $arguments): array
             {
                 return []; // Not called in this test path

--- a/tests/Capability/ToolsCapabilityTest.php
+++ b/tests/Capability/ToolsCapabilityTest.php
@@ -254,11 +254,11 @@ class ToolsCapabilityTest extends TestCase
                 $this->shutdownCountRef++;
             }
             /**
-             * @return array<Content\ContentItemInterface>
+             * @return Content\ContentItemInterface
              */
-            protected function doExecute(array $arguments): array
+            protected function doExecute(array $arguments): \MCP\Server\Tool\Content\ContentItemInterface
             {
-                return [$this->text('done')];
+                return $this->text('done');
             }
         };
 
@@ -316,11 +316,11 @@ class ToolsCapabilityTest extends TestCase
     {
         $basicTool = new #[ToolAttribute('basic', 'Basic Tool')] class extends Tool {
             /**
-             * @return array<Content\ContentItemInterface>
+             * @return Content\ContentItemInterface
              */
-            protected function doExecute(array $arguments): array
+            protected function doExecute(array $arguments): \MCP\Server\Tool\Content\ContentItemInterface
             {
-                return [$this->text('done')];
+                return $this->text('done');
             }
         };
         $this->capability->addTool($basicTool); // Add to the existing capability instance

--- a/tests/Tool/ArrayParamTool.php
+++ b/tests/Tool/ArrayParamTool.php
@@ -5,19 +5,23 @@ namespace MCP\Server\Tests\Tool;
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('array-tool', 'Tests array parameters')]
 class ArrayParamTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(
         #[ParameterAttribute('numbers', type: 'array', description: 'List of numbers')]
         #[ParameterAttribute('enabled', type: 'boolean', description: 'Whether processing is enabled')]
         array $arguments
     ): array {
         if (!$arguments['enabled']) {
-            return [$this->createTextContent('Processing disabled')];
+            return [$this->text('Processing disabled')];
         }
         $sum = array_sum($arguments['numbers']);
-        return [$this->createTextContent("Sum: $sum")];
+        return [$this->text("Sum: $sum")];
     }
 }

--- a/tests/Tool/ArrayParamTool.php
+++ b/tests/Tool/ArrayParamTool.php
@@ -11,17 +11,17 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class ArrayParamTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
     protected function doExecute(
         #[ParameterAttribute('numbers', type: 'array', description: 'List of numbers')]
         #[ParameterAttribute('enabled', type: 'boolean', description: 'Whether processing is enabled')]
         array $arguments
-    ): array {
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
         if (!$arguments['enabled']) {
-            return [$this->text('Processing disabled')];
+            return $this->text('Processing disabled');
         }
         $sum = array_sum($arguments['numbers']);
-        return [$this->text("Sum: $sum")];
+        return $this->text("Sum: $sum");
     }
 }

--- a/tests/Tool/CalculatorTool.php
+++ b/tests/Tool/CalculatorTool.php
@@ -11,20 +11,20 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class CalculatorTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
     protected function doExecute(
         #[ParameterAttribute('operation', type: 'string', description: 'Operation to perform (add/subtract)')]
         #[ParameterAttribute('a', type: 'number', description: 'First number')]
         #[ParameterAttribute('b', type: 'number', description: 'Second number')]
         array $arguments
-    ): array {
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
         $result = match ($arguments['operation']) {
             'add' => $arguments['a'] + $arguments['b'],
             'subtract' => $arguments['a'] - $arguments['b'],
             default => throw new \InvalidArgumentException('Invalid operation')
         };
 
-        return [$this->text((string)$result)];
+        return $this->text((string)$result);
     }
 }

--- a/tests/Tool/CalculatorTool.php
+++ b/tests/Tool/CalculatorTool.php
@@ -5,10 +5,14 @@ namespace MCP\Server\Tests\Tool;
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('calculator', 'A calculator tool')]
 class CalculatorTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(
         #[ParameterAttribute('operation', type: 'string', description: 'Operation to perform (add/subtract)')]
         #[ParameterAttribute('a', type: 'number', description: 'First number')]
@@ -21,6 +25,6 @@ class CalculatorTool extends Tool
             default => throw new \InvalidArgumentException('Invalid operation')
         };
 
-        return [$this->createTextContent((string)$result)];
+        return [$this->text((string)$result)];
     }
 }

--- a/tests/Tool/Helpers/AbstractTestTool.php
+++ b/tests/Tool/Helpers/AbstractTestTool.php
@@ -6,9 +6,13 @@ namespace MCP\Server\Tests\Tool\Helpers;
 
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('abstract-test-tool', 'Abstract Test Tool')]
 abstract class AbstractTestTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     abstract protected function doExecute(array $arguments): array;
 }

--- a/tests/Tool/Helpers/NoAttributeTool.php
+++ b/tests/Tool/Helpers/NoAttributeTool.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace MCP\Server\Tests\Tool\Helpers;
 
 use MCP\Server\Tool\Tool;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 class NoAttributeTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(array $arguments): array
     {
         return []; // Dummy implementation

--- a/tests/Tool/MockTool.php
+++ b/tests/Tool/MockTool.php
@@ -11,10 +11,10 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class MockTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
-    protected function doExecute(array $arguments): array
+    protected function doExecute(array $arguments): \MCP\Server\Tool\Content\ContentItemInterface
     {
-        return [$this->text('Hello World')];
+        return $this->text('Hello World');
     }
 }

--- a/tests/Tool/MockTool.php
+++ b/tests/Tool/MockTool.php
@@ -5,12 +5,16 @@ namespace MCP\Server\Tests\Tool;
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('test', 'Test Tool')]
 class MockTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(array $arguments): array
     {
-        return [$this->createTextContent('Hello World')];
+        return [$this->text('Hello World')];
     }
 }

--- a/tests/Tool/MultiOutputTool.php
+++ b/tests/Tool/MultiOutputTool.php
@@ -5,17 +5,21 @@ namespace MCP\Server\Tests\Tool;
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('multi-output', 'Tests multiple output types')]
 class MultiOutputTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(
         #[ParameterAttribute('format', type: 'string', description: 'Output format (text/image)')]
         array $arguments
     ): array {
         if ($arguments['format'] === 'text') {
-            return [$this->createTextContent('Hello world')];
+            return [$this->text('Hello world')];
         }
-        return [$this->createImageContent('fake-image-data', 'image/png')];
+        return [$this->image('fake-image-data', 'image/png')];
     }
 }

--- a/tests/Tool/MultiOutputTool.php
+++ b/tests/Tool/MultiOutputTool.php
@@ -11,15 +11,15 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class MultiOutputTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
     protected function doExecute(
         #[ParameterAttribute('format', type: 'string', description: 'Output format (text/image)')]
         array $arguments
-    ): array {
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
         if ($arguments['format'] === 'text') {
-            return [$this->text('Hello world')];
+            return $this->text('Hello world');
         }
-        return [$this->image('fake-image-data', 'image/png')];
+        return $this->image('fake-image-data', 'image/png');
     }
 }

--- a/tests/Tool/OptionalParamTool.php
+++ b/tests/Tool/OptionalParamTool.php
@@ -11,14 +11,14 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class OptionalParamTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
     protected function doExecute(
         #[ParameterAttribute('name', type: 'string', description: 'Name to greet')]
         #[ParameterAttribute('title', type: 'string', description: 'Optional title', required: false)]
         array $arguments
-    ): array {
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
         $title = $arguments['title'] ?? 'friend';
-        return [$this->text("Hello {$title} {$arguments['name']}")];
+        return $this->text("Hello {$title} {$arguments['name']}");
     }
 }

--- a/tests/Tool/OptionalParamTool.php
+++ b/tests/Tool/OptionalParamTool.php
@@ -5,16 +5,20 @@ namespace MCP\Server\Tests\Tool;
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('greeter', 'A friendly greeter')]
 class OptionalParamTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(
         #[ParameterAttribute('name', type: 'string', description: 'Name to greet')]
         #[ParameterAttribute('title', type: 'string', description: 'Optional title', required: false)]
         array $arguments
     ): array {
         $title = $arguments['title'] ?? 'friend';
-        return [$this->createTextContent("Hello {$title} {$arguments['name']}")];
+        return [$this->text("Hello {$title} {$arguments['name']}")];
     }
 }

--- a/tests/Tool/OtherMockTool.php
+++ b/tests/Tool/OtherMockTool.php
@@ -13,10 +13,10 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class OtherMockTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
-    protected function doExecute(array $arguments): array
+    protected function doExecute(array $arguments): \MCP\Server\Tool\Content\ContentItemInterface
     {
-        return [$this->text('Other Result')];
+        return $this->text('Other Result');
     }
 }

--- a/tests/Tool/OtherMockTool.php
+++ b/tests/Tool/OtherMockTool.php
@@ -7,12 +7,16 @@ use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 // ParameterAttribute is not used in this class, so it's not strictly necessary to import,
 // but kept for consistency if it might be added later or to avoid confusion.
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('other', 'Other Tool')]
 class OtherMockTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(array $arguments): array
     {
-        return [$this->createTextContent('Other Result')];
+        return [$this->text('Other Result')];
     }
 }

--- a/tests/Tool/TestTool.php
+++ b/tests/Tool/TestTool.php
@@ -5,14 +5,18 @@ namespace MCP\Server\Tests\Tool;
 use MCP\Server\Tool\Tool;
 use MCP\Server\Tool\Attribute\Tool as ToolAttribute;
 use MCP\Server\Tool\Attribute\Parameter as ParameterAttribute;
+use MCP\Server\Tool\Content\ContentItemInterface;
 
 #[ToolAttribute('test.tool', 'A test tool')]
 class TestTool extends Tool
 {
+    /**
+     * @return array<ContentItemInterface>
+     */
     protected function doExecute(
         #[ParameterAttribute('name', type: 'string', description: 'Name to greet')]
         array $arguments
     ): array {
-        return [$this->createTextContent('Hello ' . $arguments['name'])];
+        return [$this->text('Hello ' . $arguments['name'])];
     }
 }

--- a/tests/Tool/TestTool.php
+++ b/tests/Tool/TestTool.php
@@ -11,12 +11,12 @@ use MCP\Server\Tool\Content\ContentItemInterface;
 class TestTool extends Tool
 {
     /**
-     * @return array<ContentItemInterface>
+     * @return ContentItemInterface
      */
     protected function doExecute(
         #[ParameterAttribute('name', type: 'string', description: 'Name to greet')]
         array $arguments
-    ): array {
-        return [$this->text('Hello ' . $arguments['name'])];
+    ): \MCP\Server\Tool\Content\ContentItemInterface {
+        return $this->text('Hello ' . $arguments['name']);
     }
 }


### PR DESCRIPTION
This commit introduces several improvements to the `Tool` class:

1.  **Flexible Return Types for `doExecute()`:** The `Tool::doExecute()` method can now return either a single `ContentItemInterface` object or an array of `ContentItemInterface` objects. If a single item is returned, the `Tool::execute()` method automatically wraps it in an array. This simplifies tool implementation when only one content item needs to be returned, e.g., `return $this->text("response");`. The final JSON output still adheres to the Model Context Protocol, with the `content` field always being an array.

2.  **Shorter Helper Method Names:** The content creation helper methods within the `Tool` class have been renamed for brevity and consistency with similar methods in the `Resource` class:
    - `createTextContent()` is now `text()`
    - `createImageContent()` is now `image()`
    - `createAudioContent()` is now `audio()`
    - `createEmbeddedResource()` is now `embeddedResource()`

3.  **Codebase Updates:** All existing tool implementations and tests throughout the codebase have been updated to use the new helper method names.

4.  **Enhanced Testing:** `ToolTest.php` has been significantly updated with new test cases to cover:
    - Returning single text, image, audio, and embedded resource items.
    - Returning multiple content items using the new helper names.
    - Handling of invalid return types from `doExecute()`.

5.  **PHPStan and PHPUnit Fixes:** Addressed various PHPStan typing errors by adding appropriate `use` statements and refining PHPDoc annotations. Corrected PHPUnit test logic, including data passed to media helper methods and expected exception types.

I ran the `jules_setup.sh` script to ensure a consistent development environment, and the `run_tests.sh` script confirms that all tests and linters pass.