### PR TITLE
Improve code coverage for HttpTransport

### DIFF
--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -174,24 +174,9 @@ class HttpTransport implements TransportInterface
             // it might result in a parsing error on the client if it's not valid JSON-RPC (e.g. just "null").
             // For now, allow encoding null, which results in JSON "null".
             $payloadToEncode = null;
-        } else {
-            // Should not be reached due to type hints. Internal error if it does.
-            // Prepare a JSON-RPC error response.
-            $errorPayload = [
-                'jsonrpc' => '2.0',
-                'error' => [
-                    'code' => JsonRpcMessage::INTERNAL_ERROR,
-                    'message' => 'Server error: Invalid message type for sending.'
-                ],
-                'id' => null
-            ];
-            $encodedErrorString = json_encode($errorPayload);
-            $this->response = $this->responseFactory->createResponse(500)
-                ->withHeader('Content-Type', 'application/json')
-                ->withBody($this->streamFactory->createStream($encodedErrorString !== false ? $encodedErrorString : '{"jsonrpc":"2.0","error":{"code":-32000,"message":"Server JSON encoding error"}}'));
-            $this->responsePrepared = true;
-            return;
         }
+        // The 'else' block that handled non-JsonRpcMessage/array/null types has been removed
+        // as it was deemed unreachable due to PHP parameter type hints.
 
         $jsonPayloadString = json_encode($payloadToEncode);
 


### PR DESCRIPTION
This commit addresses code coverage gaps in `src/Transport/HttpTransport.php`.

Key changes include:

- **receive method**: I added tests to cover invalid item structures within batch JSON-RPC requests. I ensured that if an item in a batch is not a valid JSON object (e.g., a string or a list), a `TransportException` is thrown.
- **send method**: I investigated an `else` branch previously thought to be reachable. I determined that PHP's runtime type hinting for method parameters (`JsonRpcMessage|array|null`) makes this branch effectively unreachable. I removed the unreachable `else` block.
- **isStreamOpen method**: I added a test to confirm it correctly returns `false`, as the simplified transport does not support streaming.
- **isClosed method**: I added tests to verify its state:
    - Returns `false` immediately after transport instantiation.
    - Returns `true` after the `send()` method has been called.
- **getResponse method**: I added a test using reflection to cover a fallback scenario where the internal `$this->response` property might be `null`. This test ensures the method generates a proper error response in such a case.

All new tests pass, and existing tests continue to pass. Linters (PHPCS, PHPStan) also pass with these changes. The overall goal was to increase test coverage for the specified methods and conditions.